### PR TITLE
Check if RebuildMLO is supported for the target game and generate MLO if it isn't

### DIFF
--- a/RyuGUI/MainWindow.xaml.cs
+++ b/RyuGUI/MainWindow.xaml.cs
@@ -105,8 +105,8 @@ namespace RyuGUI
         {
             if (RyuHelpers.Program.SaveModList(this.ModList.ToList()))
             {
-                // Run generation only if it will not be run on game launch (i.e. if RebuildMLO is disabled)
-                if (RyuHelpers.Program.RebuildMLO)
+                // Run generation only if it will not be run on game launch (i.e. if RebuildMLO is disabled or unsupported)
+                if (RyuHelpers.Program.RebuildMLO && RyuHelpers.Program.IsRebuildMLOSupported)
                 {
                     MessageBox.Show("Mod list was saved. Mods will be applied next time the game is run.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
                 }

--- a/RyuHelpers/Program.cs
+++ b/RyuHelpers/Program.cs
@@ -33,6 +33,7 @@ namespace RyuHelpers
         private static Task<ConsoleOutput> updateCheck = null;
 
         public static bool RebuildMLO = true;
+        public static bool IsRebuildMLOSupported = true;
 
         public static async Task Main(string[] args)
         {
@@ -181,6 +182,8 @@ namespace RyuHelpers
             }
             else if (GamePath.GetGame() == Game.Judgment || GamePath.GetGame() == Game.LostJudgment)
             {
+                IsRebuildMLOSupported = false;
+
                 // Lost Judgment (and Judgment post update 1) does not like Ultimate ASI Loader, so instead we use a custom build of DllSpoofer (https://github.com/Kazurin-775/DllSpoofer)
                 if (File.Exists(DINPUT8DLL))
                 {


### PR DESCRIPTION
This allows the user to generate the MLO for Judgment and Lost Judgment without having to run the CLI tool separately or editing the default .ini to disable RebuildMLO